### PR TITLE
add a textual hint in the not connect help

### DIFF
--- a/src/components/SerialLoader/SerialLoader.tsx
+++ b/src/components/SerialLoader/SerialLoader.tsx
@@ -104,10 +104,15 @@ const SerialLoader = ({ children }: PropsWithChildren<SerialLoaderProps>) => {
         </button>
         <div className="pt-5">
           <i>No device found or cannot connect? </i>
-          <p>
-            Make sure you are running at least stable v2.0.0, nightly n_240114
-            or newer.
-          </p>
+          <ul>
+            <li>
+              &bull; Keep your PortaPack in normal mode (instead of HackRF mode)
+            </li>
+            <li>
+              &bull; Make sure you are running at least stable v2.0.0, nightly
+              n_240114 or newer.
+            </li>
+          </ul>
         </div>
       </div>
     </div>


### PR DESCRIPTION
“Keep your PortaPack in normal mode (instead of HackRF mode)”