### PR TITLE
Allow users to hide GUI elements

### DIFF
--- a/src/components/ToggleSwitch/ToggleSwitch.tsx
+++ b/src/components/ToggleSwitch/ToggleSwitch.tsx
@@ -1,20 +1,30 @@
 type ToggleSwitchProps = {
   isToggle: boolean;
+  toggleLabel?: string;
   toggleSwitch: () => void;
 };
 
 const ToggleSwitch: React.FC<ToggleSwitchProps> = ({
   isToggle,
+  toggleLabel,
   toggleSwitch,
 }) => {
+  const handleToggle = () => {
+    toggleSwitch()
+  }
   return (
     <label className="flex cursor-pointer items-center">
+      {toggleLabel && 
+        <div className="font-medium text-white mr-1">
+          {toggleLabel}
+        </div>
+      }
       <div className="relative">
         <input
           type="checkbox"
           className="hidden"
           checked={isToggle}
-          onChange={toggleSwitch}
+          onChange={handleToggle}
         />
         <div
           className={`h-6 w-10 rounded-full bg-gray-400 shadow-inner ${
@@ -27,9 +37,9 @@ const ToggleSwitch: React.FC<ToggleSwitchProps> = ({
           }`}
         ></div>
       </div>
-      <div className="ml-4 font-medium text-white">
+      {!toggleLabel  && <div className="ml-4 font-medium text-white">
         {isToggle ? "On" : "Off"}
-      </div>
+      </div>}
     </label>
   );
 };

--- a/src/components/ToggleSwitch/ToggleSwitch.tsx
+++ b/src/components/ToggleSwitch/ToggleSwitch.tsx
@@ -1,25 +1,27 @@
 type ToggleSwitchProps = {
   isToggle: boolean;
   toggleLabel?: string;
+  modalToggle?: boolean;
   toggleSwitch: () => void;
 };
 
 const ToggleSwitch: React.FC<ToggleSwitchProps> = ({
   isToggle,
   toggleLabel,
+  modalToggle,
   toggleSwitch,
 }) => {
   const handleToggle = () => {
     toggleSwitch()
   }
   return (
-    <label className="flex cursor-pointer items-center">
+    <label className={`flex cursor-pointer ${modalToggle? "w-full justify-between": ""}`}>
       {toggleLabel && 
         <div className="font-medium text-white mr-1">
           {toggleLabel}
         </div>
       }
-      <div className="relative">
+      <div className={`relative ${modalToggle? "right-0": ""}`}>
         <input
           type="checkbox"
           className="hidden"


### PR DESCRIPTION
This PR addresses issues #55 and #68 of MayhemHub repository.
The proposal is the implementation of localStorage variables to manage the user disabled widgets. The values are loaded on the component mount so the user has persistance in the browser(maybe it would be good exploring a way of saving these values on the portapack so it can be recovered with the serial connection making it work on any device, but maybe its a bit overkill).
Example UI widget setups:
<img src="https://github.com/user-attachments/assets/74284135-8b84-46cc-9a0a-56421cc12f01" width="50%"/>
<img src="https://github.com/user-attachments/assets/fa16ca7f-88e5-4d35-95af-8f526416ccb1" width="50%"/>
<img src="https://github.com/user-attachments/assets/ef6c0a2f-82a6-4472-8c6d-d9e30d834af4" width="50%"/>
<img src="https://github.com/user-attachments/assets/4320dafe-f566-4443-9dd2-95f6da888398" width="50%"/>
<img src="https://github.com/user-attachments/assets/c34bbef2-073d-434e-9f9e-a2f6c64c16a2" width="50%"/>
