### PR TITLE
Implement UI disable

### DIFF
--- a/src/components/Controller/Controller.tsx
+++ b/src/components/Controller/Controller.tsx
@@ -16,7 +16,7 @@ import { useSerial } from "@/components/SerialLoader/SerialLoader";
 import ToggleSwitch from "@/components/ToggleSwitch/ToggleSwitch";
 import { useDeviceSetup } from "@/hooks/useDeviceSetup";
 import { useScreenFrame } from "@/hooks/useScreenFrame";
-import { ILatestVersions } from "@/types";
+import { ILatestVersions, IUIConfig } from "@/types";
 import { downloadFileFromUrl, useWriteCommand } from "@/utils/serialUtils";
 import {
   getVersionType,
@@ -42,6 +42,15 @@ const Controller = () => {
   const firmwareFileInputRef = useRef<HTMLInputElement>(null);
   const scriptFileInputRef = useRef<HTMLInputElement>(null);
 
+  const [UIConfigurationOpen, setUIConfigurationOpen] = useState<boolean>(false);
+  const [UIConfig, setUiConfig] = useState<IUIConfig>({
+    controlDeviceHide: false,
+    disableButtonGroup: false,
+    fileSystemHide: false,
+    serialConnectionHide: false,
+    firmwareUpdateHide: false
+  });
+
   const { serial, consoleMessage } = useSerial();
   const { write, uploadFile, disableTransmitAction, setLoadingFrame } =
     useWriteCommand();
@@ -60,9 +69,25 @@ const Controller = () => {
   };
 
   useEffect(() => {
+    const cdh = localStorage.getItem('controlDeviceHide')
+    const dbg = localStorage.getItem('disableButtonGroup')
+    const fsh = localStorage.getItem('fileSystemHide')
+    const sch = localStorage.getItem('serialConnectionHide')
+    const fuh = localStorage.getItem('firmwareUpdateHide')
+    const newConfig: IUIConfig = {
+      controlDeviceHide: cdh? Boolean(Number(cdh)): false,
+      disableButtonGroup: dbg? Boolean(Number(dbg)): false,
+      fileSystemHide: fsh? Boolean(Number(fsh)): false,
+      serialConnectionHide: sch? Boolean(Number(sch)): false,
+      firmwareUpdateHide: fuh? Boolean(Number(fuh)): false,
+    }
+    if (cdh || dbg || fsh || sch || fuh) setUiConfig(newConfig)
+  }, []);
+
+  useEffect(() => {
     // We dont add this to the console as its not needed. This may change in the future
     if (consoleMessage.startsWith("screenframe")) {
-      renderFrame(consoleMessage);
+      if(!UIConfig.controlDeviceHide) renderFrame(consoleMessage);
       setLoadingFrame(false);
     } else {
       setConsoleMessageList(
@@ -266,6 +291,20 @@ const Controller = () => {
     }
   };
 
+  const handleButtonControlClick = (button: string) => {
+    if (UIConfig.controlDeviceHide) {
+      write(button, false)
+      return
+    }
+    write(button, autoUpdateFrame)
+  }
+
+  const handleUpdateUiHide = (value: boolean, lsKey: string, setInState: (stateValue: boolean) => void) => {
+    const updatedValue = !value
+    localStorage.setItem(lsKey, String(Number(updatedValue)))
+    setInState(updatedValue)
+  }
+
   return (
     <>
       {setupComplete ? (
@@ -276,62 +315,63 @@ const Controller = () => {
               className="pl-2 text-green-500"
               icon={faCheckCircle}
             />
-          </h1>
+          </h1>          
           {!serial.isReading &&
             "Please enable the console, so the buttons can also be enabled!"}
-          <div
-            id="ControllerSection"
-            className="flex h-full max-w-[80%] flex-col items-center justify-center gap-24 rounded-lg bg-slate-800 p-10 outline-none focus:ring-0 md:flex-row md:items-start"
-            onWheel={handleScroll}
-            tabIndex={0}
-            onKeyDown={(e) => {
-              handleKeyDown(e);
-            }}
-          >
-            <div
-              className="flex flex-col items-center justify-center gap-5"
-              id="screenGroup"
+            {(!UIConfig.controlDeviceHide || !UIConfig.disableButtonGroup) && <div
+              id="ControllerSection"
+              className="flex h-full max-w-[80%] flex-col items-center justify-center gap-24 rounded-lg bg-slate-800 p-10 outline-none focus:ring-0 md:flex-row md:items-start"
+              onWheel={handleScroll}
+              tabIndex={0}
+              onKeyDown={(e) => {
+                handleKeyDown(e);
+              }}
             >
+            {!UIConfig.controlDeviceHide && <div
+                className="flex flex-col items-center justify-center gap-5"
+                id="screenGroup"
+              >
               <Screen
                 canvasRef={canvasRef}
                 disableTransmitAction={disableTransmitAction}
                 autoUpdateFrame={autoUpdateFrame}
                 write={write}
-              />
+                />
 
-              <div className="flex flex-col items-center justify-center rounded-md bg-gray-700 p-3">
-                <p className="pb-4">Live Screen</p>
-                <div className="flex flex-row items-center justify-center gap-5">
-                  <ToggleSwitch
-                    isToggle={autoUpdateFrame}
-                    toggleSwitch={() => {
-                      if (!autoUpdateFrame) write("screenframeshort", false);
-                      setAutoUpdateFrame(!autoUpdateFrame);
-                    }}
-                  />
-                  <HotkeyButton
-                    label={<FontAwesomeIcon icon={faRotate} />}
-                    disabled={disableTransmitAction}
-                    onClickFunction={() => {
-                      if (!disableTransmitAction) {
-                        setLoadingFrame(true);
-                        write("screenframeshort", false);
-                      }
-                    }}
-                    className={"h-6 w-6 rounded-sm bg-green-500"}
-                    shortcutKeys={"mod+R"}
-                  />
+                <div className="flex flex-col items-center justify-center rounded-md bg-gray-700 p-3">
+                  <p className="pb-4">Live Screen</p>
+                  <div className="flex flex-row items-center justify-center gap-5">
+                    <ToggleSwitch
+                      isToggle={autoUpdateFrame}
+                      toggleSwitch={() => {
+                        if (!autoUpdateFrame) write("screenframeshort", false);
+                        setAutoUpdateFrame(!autoUpdateFrame);
+                      }}
+                    />
+                    <HotkeyButton
+                      label={<FontAwesomeIcon icon={faRotate} />}
+                      disabled={disableTransmitAction}
+                      onClickFunction={() => {
+                        if (!disableTransmitAction) {
+                          setLoadingFrame(true);
+                          write("screenframeshort", false);
+                        }
+                      }}
+                      className={"h-6 w-6 rounded-sm bg-green-500"}
+                      shortcutKeys={"mod+R"}
+                    />
+                  </div>
                 </div>
-              </div>
-            </div>
+            </div>}
 
-            <DeviceControls
-              disableTransmitAction={disableTransmitAction}
+            {!UIConfig.disableButtonGroup && <DeviceControls
+                disableTransmitAction={disableTransmitAction}
               write={write}
               autoUpdateFrame={autoUpdateFrame}
-            />
-          </div>
-
+              handleButtonClick={handleButtonControlClick}
+            />}
+            </div>}
+          
           {!serial.isReading ? (
             <button
               className="rounded bg-orange-300 p-2 text-white disabled:opacity-50"
@@ -341,20 +381,20 @@ const Controller = () => {
             </button>
           ) : (
             <>
-              <div className="mt-10 flex h-[434px] w-[80%] flex-row items-start justify-center gap-5 rounded-md bg-gray-700 p-5">
-                <FileInputs
-                  fileInputRef={fileInputRef}
+              {(!UIConfig.fileSystemHide || !UIConfig.serialConnectionHide) && <div className="mt-10 flex h-[434px] max-w-[80%] flex-row items-start justify-center gap-5 rounded-md bg-gray-700 p-5">
+                {!UIConfig.fileSystemHide && <FileInputs
+                          fileInputRef={fileInputRef}
                   firmwareFileInputRef={firmwareFileInputRef}
                   scriptFileInputRef={scriptFileInputRef}
                   selectedUploadFolder={selectedUploadFolder}
-                  dirStructure={dirStructure}
-                  setDirStructure={setDirStructure}
+                          dirStructure={dirStructure}
+                          setDirStructure={setDirStructure}
                   setSelectedUploadFolder={setSelectedUploadFolder}
                   onFileChange={onFileChange}
                   onFirmwareFileChange={onFirmwareFileChange}
                   onScriptFileChange={onScriptFileChange}
-                />
-                <Console
+                />}
+                {!UIConfig.serialConnectionHide && <Console
                   consoleMessageList={consoleMessageList}
                   command={command}
                   setCommand={setCommand}
@@ -363,17 +403,25 @@ const Controller = () => {
                   scriptStatus={scriptStatus}
                   scriptRunning={scriptRunning}
                   scriptFileInputRef={scriptFileInputRef}
-                />
-              </div>
-              <div className="m-5 flex w-[20%] flex-col items-center justify-center rounded-md bg-gray-700 p-5">
-                <p className="pb-5 text-center text-sm">
-                  Firmware Version: {deviceVersion}
-                </p>
+                        />}
+                </div>}
+                {!UIConfig.firmwareUpdateHide && <div className="m-5 flex w-[20%] flex-col items-center justify-center rounded-md bg-gray-700 p-5">
+                  <p className="pb-5 text-center text-sm">
+                    Firmware Version: {deviceVersion}
+                  </p>
+                  <button
+                    onClick={() => setFirmwarModalOpen(true)}
+                    className="btn btn-info"
+                  >
+                    Manage Firmware
+                  </button>
+                </div>}
+              <div className="mt-3 flex w-[80%] justify-end">
                 <button
-                  onClick={() => setFirmwarModalOpen(true)}
-                  className="btn btn-info"
+                  onClick={() => setUIConfigurationOpen(true)}
+                  className=" btn btn-secondary"
                 >
-                  Manage Firmware
+                  UI Configuration
                 </button>
               </div>
             </>
@@ -409,6 +457,58 @@ const Controller = () => {
             flashLatestNightlyFirmware={flashLatestNightlyFirmware}
           />
         )}
+      </Modal>
+      <Modal
+        title="UI Configuration"
+        isModalOpen={UIConfigurationOpen}
+        closeModal={() => setUIConfigurationOpen(false)}
+        className="w-[40%]"
+      >
+        <div className="mb-3 flex flex-col items-center justify-center rounded-lg p-4 font-medium text-white outline-none focus:ring-0 md:items-start">
+          <div className="flex w-full flex-col items-start justify-start gap-5 ">
+            <ToggleSwitch
+              toggleLabel="Hide Buttons"
+              isToggle={UIConfig.disableButtonGroup}
+              toggleSwitch={() => {
+                handleUpdateUiHide(UIConfig.disableButtonGroup, "disableButtonGroup", (updatedValue) => setUiConfig({...UIConfig, disableButtonGroup: updatedValue}))
+              }}
+              modalToggle
+            />
+            <ToggleSwitch
+              toggleLabel="Hide Screen"
+              isToggle={UIConfig.controlDeviceHide}
+              toggleSwitch={() => {
+                handleUpdateUiHide(UIConfig.controlDeviceHide, "controlDeviceHide", (updatedValue) => setUiConfig({...UIConfig, controlDeviceHide: updatedValue}))
+                write("screenframeshort", false)
+              }}
+              modalToggle
+            />
+            <ToggleSwitch
+              toggleLabel="Hide File System"
+              isToggle={UIConfig.fileSystemHide}
+              toggleSwitch={() => {
+                handleUpdateUiHide(UIConfig.fileSystemHide, "fileSystemHide", (updatedValue) => setUiConfig({...UIConfig, fileSystemHide: updatedValue}))
+              }}
+              modalToggle
+            />
+            <ToggleSwitch
+              toggleLabel="Hide Serial"
+              isToggle={UIConfig.serialConnectionHide}
+              toggleSwitch={() => {
+                handleUpdateUiHide(UIConfig.serialConnectionHide, "serialConnectionHide", (updatedValue) => setUiConfig({...UIConfig, serialConnectionHide: updatedValue}))
+              }}
+              modalToggle
+            />
+            <ToggleSwitch
+              toggleLabel="Hide Firmware Update"
+              isToggle={UIConfig.firmwareUpdateHide}
+              toggleSwitch={() => {
+                handleUpdateUiHide(UIConfig.firmwareUpdateHide, "firmwareUpdateHide", (updatedValue) => setUiConfig({...UIConfig, firmwareUpdateHide: updatedValue}))
+              }}
+              modalToggle
+            />
+          </div>
+        </div>
       </Modal>
     </>
   );

--- a/src/components/Controller/Controller.tsx
+++ b/src/components/Controller/Controller.tsx
@@ -419,9 +419,9 @@ const Controller = () => {
               <div className="mt-3 flex w-[80%] justify-end">
                 <button
                   onClick={() => setUIConfigurationOpen(true)}
-                  className=" btn btn-secondary"
+                  className="btn btn-primary"
                 >
-                  UI Configuration
+                  UI Config
                 </button>
               </div>
             </>

--- a/src/components/DeviceControls/DeviceControls.tsx
+++ b/src/components/DeviceControls/DeviceControls.tsx
@@ -15,12 +15,14 @@ interface IDeviceControls {
   disableTransmitAction: boolean;
   autoUpdateFrame: boolean;
   write: any;
+  handleButtonClick:(button: string) => void;
 }
 
 export const DeviceControls: React.FC<IDeviceControls> = ({
   disableTransmitAction,
   autoUpdateFrame,
   write,
+  handleButtonClick,
 }) => {
   /* 
 
@@ -51,13 +53,13 @@ export const DeviceControls: React.FC<IDeviceControls> = ({
           <HotkeyButton
             label={<FontAwesomeIcon icon={faArrowLeft} />}
             disabled={disableTransmitAction}
-            onClickFunction={() => write("button 2", autoUpdateFrame)}
+            onClickFunction={() => handleButtonClick("button 2")}
             className="btn btn-success h-16 w-16"
             shortcutKeys={"ArrowLeft"}
           />
           <button
             disabled={disableTransmitAction}
-            onClick={() => write("button 7", autoUpdateFrame)}
+            onClick={() => handleButtonClick("button 7")}
             className="btn btn-info h-12 w-12 self-end justify-self-start"
           >
             <FontAwesomeIcon icon={faRotateLeft} />
@@ -65,21 +67,21 @@ export const DeviceControls: React.FC<IDeviceControls> = ({
           <HotkeyButton
             label={<FontAwesomeIcon icon={faArrowUp} />}
             disabled={disableTransmitAction}
-            onClickFunction={() => write("button 4", autoUpdateFrame)}
+            onClickFunction={() => handleButtonClick("button 4")}
             className="btn btn-success h-16 w-16"
             shortcutKeys={"ArrowUp"}
           />
           <HotkeyButton
             label={<FontAwesomeIcon icon={faCheckCircle} />}
             disabled={disableTransmitAction}
-            onClickFunction={() => write("button 5", autoUpdateFrame)}
+            onClickFunction={() => handleButtonClick("button 5")}
             className="btn btn-info h-16 w-16"
             shortcutKeys={"Enter"}
           />
           <HotkeyButton
             label={<FontAwesomeIcon icon={faArrowDown} />}
             disabled={disableTransmitAction}
-            onClickFunction={() => write("button 3", autoUpdateFrame)}
+            onClickFunction={() => handleButtonClick("button 3")}
             className="btn btn-success h-16 w-16"
             shortcutKeys={"ArrowDown"}
           />
@@ -87,13 +89,13 @@ export const DeviceControls: React.FC<IDeviceControls> = ({
           <HotkeyButton
             label={<FontAwesomeIcon icon={faArrowRight} />}
             disabled={disableTransmitAction}
-            onClickFunction={() => write("button 1", autoUpdateFrame)}
+            onClickFunction={() => handleButtonClick("button 1")}
             className="btn btn-success h-16 w-16"
             shortcutKeys={"ArrowRight"}
           />
           <button
             disabled={disableTransmitAction}
-            onClick={() => write("button 8", autoUpdateFrame)}
+            onClick={() => handleButtonClick("button 8")}
             className="btn btn-info h-12 w-12 self-end justify-self-end"
           >
             <FontAwesomeIcon icon={faRotateRight} />

--- a/src/components/FileInputs/FileInputs.tsx
+++ b/src/components/FileInputs/FileInputs.tsx
@@ -33,7 +33,7 @@ export const FileInputs: React.FC<IFileInputs> = ({
   onScriptFileChange,
 }) => {
   return (
-    <div className="flex h-full w-[35%] flex-col gap-1">
+    <div className="flex h-full flex-col gap-1">
       <input
         ref={fileInputRef}
         type="file"

--- a/src/components/ToggleSwitch/ToggleSwitch.tsx
+++ b/src/components/ToggleSwitch/ToggleSwitch.tsx
@@ -1,17 +1,32 @@
 type IToggleSwitch = {
   isToggle: boolean;
+  toggleLabel?: string;
+  modalToggle?: boolean;
   toggleSwitch: () => void;
 };
 
-const ToggleSwitch: React.FC<IToggleSwitch> = ({ isToggle, toggleSwitch }) => {
+const ToggleSwitch: React.FC<IToggleSwitch> = ({
+  isToggle,
+  toggleLabel,
+  modalToggle,
+  toggleSwitch,
+}) => {
+  const handleToggle = () => {
+    toggleSwitch()
+  }
   return (
-    <label className="flex cursor-pointer items-center">
-      <div className="relative">
+    <label className={`flex cursor-pointer ${modalToggle? "w-full justify-between": ""}`}>
+      {toggleLabel && 
+        <div className="mr-1 font-medium text-white">
+          {toggleLabel}
+        </div>
+      }
+      <div className={`relative ${modalToggle? "right-0": ""}`}>
         <input
           type="checkbox"
           className="hidden"
           checked={isToggle}
-          onChange={toggleSwitch}
+          onChange={handleToggle}
         />
         <div
           className={`h-6 w-10 rounded-full bg-gray-400 shadow-inner ${
@@ -24,9 +39,9 @@ const ToggleSwitch: React.FC<IToggleSwitch> = ({ isToggle, toggleSwitch }) => {
           }`}
         ></div>
       </div>
-      <div className="ml-4 font-medium text-white">
+      {!toggleLabel  && <div className="ml-4 font-medium text-white">
         {isToggle ? "On" : "Off"}
-      </div>
+      </div>}
     </label>
   );
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -29,3 +29,11 @@ export interface ISerialContextValue {
   serial: ISerialProvider;
   consoleMessage: string;
 }
+
+export interface IUIConfig {
+  controlDeviceHide: boolean;
+  disableButtonGroup: boolean;
+  fileSystemHide: boolean;
+  serialConnectionHide: boolean;
+  firmwareUpdateHide: boolean;
+}


### PR DESCRIPTION
Fixes issues #55 and #68.
Implements a configuration to hide/disable UI components. This object is stored in the browser localstorage.
The comments of the old PR where addressed. Config is now an object, the button is of a smoother color and smaller. It also integrates the changes to the new refactor done to the code.
