### PR TITLE
Refac: implement UI configuration modal and refactor UI state management

### DIFF
--- a/src/components/UIConfigurationModal/UIConfigurationModal.tsx
+++ b/src/components/UIConfigurationModal/UIConfigurationModal.tsx
@@ -1,0 +1,82 @@
+import Modal from "@/components/Modal/Modal";
+import ToggleSwitch from "@/components/ToggleSwitch/ToggleSwitch";
+import { ConfigItem, IUIConfig } from "@/types";
+
+interface IUIConfigurationModal {
+  isOpen: boolean;
+  onClose: () => void;
+  UIConfig: IUIConfig;
+  setUiConfig: (config: IUIConfig) => void;
+  handleUpdateUiHide: (
+    value: boolean,
+    key: keyof IUIConfig,
+    setInState: (stateValue: boolean) => void
+  ) => void;
+  toggleLiveScreen: (shouldUpdate: boolean) => void;
+}
+
+const UIConfigurationModal: React.FC<IUIConfigurationModal> = ({
+  isOpen,
+  onClose,
+  UIConfig,
+  setUiConfig,
+  handleUpdateUiHide,
+  toggleLiveScreen,
+}) => {
+  const uiConfigItems: ConfigItem[] = [
+    {
+      key: "controlButtonsHide",
+      label: "Hide Control Buttons",
+    },
+    {
+      key: "screenHide",
+      label: "Hide Screen",
+      onToggle: () => toggleLiveScreen(!UIConfig.screenHide),
+    },
+    {
+      key: "fileSystemHide",
+      label: "Hide File System",
+    },
+    {
+      key: "serialConsoleHide",
+      label: "Hide Serial Console",
+    },
+    {
+      key: "firmwareManagerHide",
+      label: "Hide Firmware Manager",
+    },
+  ];
+
+  return (
+    <Modal
+      title="UI Configuration"
+      isModalOpen={isOpen}
+      closeModal={onClose}
+      className="w-[20%]"
+    >
+      <div className="mb-3 flex flex-col items-center justify-center rounded-lg p-4 font-medium text-white outline-none focus:ring-0 md:items-start">
+        <div className="flex w-full flex-col items-start justify-start gap-5">
+          {uiConfigItems.map((item) => (
+            <ToggleSwitch
+              key={item.key}
+              toggleLabel={item.label}
+              isToggle={UIConfig[item.key]}
+              toggleSwitch={() => {
+                handleUpdateUiHide(
+                  UIConfig[item.key],
+                  item.key,
+                  (updatedValue) => {
+                    setUiConfig({ ...UIConfig, [item.key]: updatedValue });
+                    item.onToggle?.();
+                  }
+                );
+              }}
+            />
+          ))}
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default UIConfigurationModal;

--- a/src/hooks/useUIConfig.ts
+++ b/src/hooks/useUIConfig.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from "react";
+import { IUIConfig } from "@/types";
+
+export const useUIConfig = () => {
+  const [UIConfig, setUiConfig] = useState<IUIConfig>({
+    screenHide: false,
+    controlButtonsHide: false,
+    fileSystemHide: false,
+    serialConsoleHide: false,
+    firmwareManagerHide: false,
+  });
+
+  const handleUpdateUiHide = (
+    value: boolean,
+    key: keyof IUIConfig,
+    setInState: (stateValue: boolean) => void
+  ) => {
+    const updatedValue = !value;
+    const newConfig = { ...UIConfig, [key]: updatedValue };
+    localStorage.setItem("uiConfig", JSON.stringify(newConfig));
+    setInState(updatedValue);
+  };
+
+  useEffect(() => {
+    const storedConfig = localStorage.getItem("uiConfig");
+    if (storedConfig) {
+      setUiConfig(JSON.parse(storedConfig));
+    }
+  }, []);
+
+  return { UIConfig, setUiConfig, handleUpdateUiHide };
+};


### PR DESCRIPTION
# UI Configuration Refactor

## Changes
- Created a new `UIConfigurationModal` component to handle UI configuration settings
- Introduced `useUIConfig` custom hook to manage UI configuration state and logic
- Removed redundant imports and cleaned up code organization

## Details
- Extracted UI configuration modal logic into a separate component for better maintainability
- Moved UI configuration state management into a custom hook for reusability
- Improved code organization by separating concerns
- Removed unused `faGears` import
- Maintained existing functionality while making the code more modular

## Testing
- Verified that UI configuration modal works as expected
- Confirmed that all toggle switches function correctly
- Tested localStorage persistence of UI settings
- Ensured screen toggle functionality remains intact

## Impact
This refactor improves code maintainability and follows better React practices by:
- Separating UI components into smaller, focused pieces
- Extracting state management logic into custom hooks
- Making the code more reusable and easier to test

No breaking changes were introduced, and all existing functionality remains the same.