### PR TITLE
[ONLY MERGE AFTER NEXT MAYHEM RELEASE] Fix macOS file transfer

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-# NEXT_PUBLIC_BASE_PATH='/MayhemHub'
+NEXT_PUBLIC_BASE_PATH='/MayhemHub'

--- a/src/components/SerialProvider/SerialProvider.tsx
+++ b/src/components/SerialProvider/SerialProvider.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { IDataPacket } from "@/types";
-import { isMac } from "@/utils/serialUtils";
 
 // Needing to do this as the typescript definitions for the Web Serial API are not yet complete
 interface IWebSerialPort extends SerialPort {
@@ -125,8 +124,7 @@ const useWebSerial = ({
   const [isReading, setIsReading] = useState<boolean>(false);
   const isIncomingMessage = useRef<boolean>(false);
   const [baudRate, setBaudRate] = useState<BaudRatesType>(115200);
-  // Use larger buffer for macOS to prevent serial issues
-  const [bufferSize, setBufferSize] = useState(isMac() ? 4096 : 30);
+  const [bufferSize, setBufferSize] = useState(4096);
   const [dataBits, setDataBits] = useState<DataBitsType>(8);
   const [stopBits, setStopBits] = useState<StopBitsType>(1);
   const [flowControl, setFlowControl] = useState<FlowControlType>("none");
@@ -363,16 +361,12 @@ const useWebSerial = ({
     port.cancelRequested = true;
   };
 
-  const delay = (ms: number) => {
-    return new Promise((resolve) => setTimeout(resolve, ms));
-  };
-
   /**
    *
    * @param {string} message
    */
   const write = useCallback(async () => {
-    if (messageQueue.length === 0 || (!isMac() && isIncomingMessage.current)) {
+    if (messageQueue.length === 0 || isIncomingMessage.current) {
       return;
     }
 
@@ -382,22 +376,10 @@ const useWebSerial = ({
     const writer = port?.writable?.getWriter();
     if (writer) {
       try {
-        if (isMac()) {
-          // macOS fix: Write in small chunks with delays to prevent serial buffer overflow
-          const chunkSize = 64;
-          for (let i = 0; i < data.byteLength; i += chunkSize) {
-            const chunk = data.slice(i, i + chunkSize);
-            await delay(2);
-            await writer.write(chunk);
-          }
-        } else {
-          // other platforms: direct write
-          await writer.write(data);
-          writer.releaseLock();
-        }
+        await writer.write(data);
         setMessageQueue((prevQueue) => prevQueue.slice(1)); // Remove the message we just wrote from the queue
       } catch (e) {
-        console.error('Serial write error:', e);
+        console.error("Serial write error:", e);
         // Optionally still remove from queue or handle retry logic
       } finally {
         writer.releaseLock();

--- a/src/utils/serialUtils.tsx
+++ b/src/utils/serialUtils.tsx
@@ -109,8 +109,7 @@ export const useWriteCommand = () => {
     let blob = new Blob([bytes]);
     const arrayBuffer = await blob.arrayBuffer();
   
-    // macOS needs smaller chunks to prevent serial buffer overflow
-    const chunkSize = isMac() ? 4096 : 100000;
+    const chunkSize = 100000;
     let successfulChunks = 0;
     let failedChunks = 0;
   


### PR DESCRIPTION
# TLDR
This removes the macOS specific limits that caused by a fw end error. That had been fixed now, so I removed the limits here but kept the mac banner.

ref. https://github.com/portapack-mayhem/mayhem-firmware/pull/3248

This is **not** the fix itself, I'm aware that "removing the limitation" is not the fix, this changes just because the issue is gone, so limits here can gone too.